### PR TITLE
Image Upload Feature (Temporarily Disabled)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,7 +2,10 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
     <uses-permission android:name="android.permission.INTERNET" />
-
+    <!-- Android 13+ -->
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <!-- Legacy permission for older Android versions -->
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
 
     <application
         android:allowBackup="true"

--- a/app/src/main/java/com/example/wheeldeal/repository/StorageRepository.kt
+++ b/app/src/main/java/com/example/wheeldeal/repository/StorageRepository.kt
@@ -1,0 +1,24 @@
+package com.example.wheeldeal.repository
+/*
+import android.net.Uri
+import com.google.firebase.storage.FirebaseStorage
+import kotlinx.coroutines.tasks.await
+import java.util.*
+
+class StorageRepository {
+
+    private val storage = FirebaseStorage.getInstance()
+    private val storageRef = storage.reference.child("car_images")
+
+    suspend fun uploadImage(uri: Uri): Result<String> {
+        return try {
+            val imageRef = storageRef.child("${UUID.randomUUID()}.jpg")
+            imageRef.putFile(uri).await()
+            val downloadUrl = imageRef.downloadUrl.await().toString()
+            Result.success(downloadUrl)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+}
+*/

--- a/app/src/main/java/com/example/wheeldeal/ui/screens/SellScreen.kt
+++ b/app/src/main/java/com/example/wheeldeal/ui/screens/SellScreen.kt
@@ -36,9 +36,17 @@ import com.example.wheeldeal.viewmodel.ListingState
 import com.example.wheeldeal.viewmodel.ListingViewModel
 import com.google.firebase.auth.FirebaseAuth
 
+//  import android.net.Uri
+//  import androidx.activity.compose.rememberLauncherForActivityResult
+//  import androidx.activity.result.contract.ActivityResultContracts
+
+
+
+
 @Composable
 fun SellScreen(viewModel: ListingViewModel = viewModel()) {
     val context = LocalContext.current
+
     val listingState by viewModel.listingState.collectAsState()
     val currentUserId = FirebaseAuth.getInstance().currentUser?.uid.orEmpty()
 
@@ -152,6 +160,22 @@ fun SellScreen(viewModel: ListingViewModel = viewModel()) {
             }
         }
     }
+    /*val launcher = rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri: Uri? ->
+        uri?.let {
+            val storageRepo = StorageRepository()
+            CoroutineScope(Dispatchers.IO).launch {
+                val result = storageRepo.uploadImage(uri)
+                withContext(Dispatchers.Main) {
+                    result.onSuccess { url ->
+                        photoUrl = url
+                        Toast.makeText(context, "Image uploaded", Toast.LENGTH_SHORT).show()
+                    }.onFailure {
+                        Toast.makeText(context, "Upload failed", Toast.LENGTH_SHORT).show()
+                    }
+                }
+            }
+        }
+    }*/
 
     // Main layout with lazy column
     LazyColumn(
@@ -242,6 +266,16 @@ fun SellScreen(viewModel: ListingViewModel = viewModel()) {
                         }
                         // Photo
                         InputField("Photo URL", photoUrl) { photoUrl = it }
+                        /*
+                        Button(
+                        onClick = { launcher.launch("image/*") },
+                        colors = ButtonDefaults.buttonColors(containerColor = FontIconColor)
+                            ) {
+                             Text("Upload Image", color = WhiteColor)
+                            }
+                            Text("Photo URL: $photoUrl", style = MaterialTheme.typography.bodySmall, color = FontIconColor)*/
+
+                         */
                         // Description
                         InputField("Description", description, singleLine = false) { description = it }
 


### PR DESCRIPTION
Implemented functionality to allow users to upload car images using Firebase Storage and Jetpack Compose. The UI includes an upload button that lets users select images from device storage, and the images are uploaded and displayed upon success. However, the feature has been temporarily disabled due to Firebase billing limitations (Storage requires Blaze plan). Functionality can be restored once billing is upgraded.