### PR TITLE
Add end‑to‑end chat feature: repository, navigation, and UI

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -26,6 +26,9 @@
           </targets>
         </DialogSelection>
       </SelectionState>
+      <SelectionState runConfigName="ChatScreen">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
     </selectionStates>
   </component>
 </project>

--- a/app/src/main/java/com/example/wheeldeal/repository/ChatRepository.kt
+++ b/app/src/main/java/com/example/wheeldeal/repository/ChatRepository.kt
@@ -92,4 +92,33 @@ class ChatRepository {
 
         awaitClose { listener.remove() }
     }
+    /** fetch all chats involving this user */
+    suspend fun getChatsForUser(userId: String): List<Chat> {
+        val db = FirebaseFirestore.getInstance()
+        val results = mutableListOf<Chat>()
+
+        // Query where user1Id == you
+        db.collection("chats")
+            .whereEqualTo("user1Id", userId)
+            .get().await()
+            .documents
+            .forEach { snap ->
+                snap.toObject(Chat::class.java)
+                    ?.copy(id = snap.id)
+                    ?.let { results.add(it) }
+            }
+
+        // Query where user2Id == you
+        db.collection("chats")
+            .whereEqualTo("user2Id", userId)
+            .get().await()
+            .documents
+            .forEach { snap ->
+                snap.toObject(Chat::class.java)
+                    ?.copy(id = snap.id)
+                    ?.let { results.add(it) }
+            }
+
+        return results
+    }
 }

--- a/app/src/main/java/com/example/wheeldeal/ui/navigation/Screen.kt
+++ b/app/src/main/java/com/example/wheeldeal/ui/navigation/Screen.kt
@@ -21,7 +21,10 @@ sealed class Screen(val route: String) {
     }
 
     object Chat : Screen("chat/{chatId}/{receiverId}") {
-              fun createRoute(chatId: String, receiverId: String) =
-                    "chat/$chatId/$receiverId"
-            }
+        fun createRoute(chatId: String, receiverId: String) = "chat/$chatId/$receiverId"
+    }
+
+    object ChatList : Screen("chatList") {
+        fun createRoute() = "chatList"
+    }
 }

--- a/app/src/main/java/com/example/wheeldeal/ui/screens/ChatListScreen.kt
+++ b/app/src/main/java/com/example/wheeldeal/ui/screens/ChatListScreen.kt
@@ -1,0 +1,2 @@
+package com.example.wheeldeal.ui.screens
+

--- a/app/src/main/java/com/example/wheeldeal/ui/screens/ChatListScreen.kt
+++ b/app/src/main/java/com/example/wheeldeal/ui/screens/ChatListScreen.kt
@@ -1,2 +1,155 @@
 package com.example.wheeldeal.ui.screens
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavHostController
+import com.example.wheeldeal.model.Chat
+import com.example.wheeldeal.repository.ChatRepository
+import com.example.wheeldeal.ui.navigation.Screen
+import com.example.wheeldeal.ui.theme.*
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.firestore.FirebaseFirestore
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
+
+@Composable
+fun ChatListScreen(navController: NavHostController) {
+    val currentUserId = FirebaseAuth.getInstance().currentUser?.uid.orEmpty()
+    var chats by remember { mutableStateOf<List<Chat>>(emptyList()) }
+    val scope = rememberCoroutineScope()
+
+    // Load chat metadata once
+    LaunchedEffect(currentUserId) {
+        scope.launch {
+            chats = ChatRepository().getChatsForUser(currentUserId)
+        }
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(WhiteColor)
+    ) {
+        // ─── Header ─────
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(FontIconColor)
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            IconButton(
+                onClick = { navController.popBackStack() },
+                modifier = Modifier.size(36.dp)
+            ) {
+                Icon(
+                    Icons.AutoMirrored.Filled.ArrowBack,
+                    contentDescription = "Back",
+                    tint = WhiteColor
+                )
+            }
+            Text(
+                text = "Your Chats",
+                style = AppTypography.headlineLarge.copy(color = WhiteColor),
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(start = 8.dp)
+            )
+        }
+        // ─── Chat List ────
+        LazyColumn(
+            modifier = Modifier.fillMaxSize(),
+            contentPadding = PaddingValues(vertical = 12.dp),
+            verticalArrangement = Arrangement.spacedBy(15.dp)
+        ) {
+            items(chats, key = { it.id }) { chat ->
+                val otherId = if (chat.user1Id == currentUserId) chat.user2Id else chat.user1Id
+                val displayName by produceState(initialValue = "", key1 = otherId) {
+                    val doc = FirebaseFirestore.getInstance()
+                        .collection("users")
+                        .document(otherId)
+                        .get()
+                        .await()
+                    val f = doc.getString("firstName").orEmpty()
+                    val l = doc.getString("lastName").orEmpty()
+                    value = listOf(f, l)
+                        .filter { it.isNotBlank() }
+                        .joinToString(" ")
+                        .ifBlank { otherId }
+                }
+
+                Surface(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp)
+                        .clickable { navController.navigate(Screen.Chat.createRoute(chat.id, otherId)) },
+                    shape = RoundedCornerShape(12.dp),
+                    color = WhiteColor,
+                    shadowElevation = 2.dp
+                ) {
+                    Row(
+                        modifier = Modifier.padding(12.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        // avatar placeholder
+                        Surface(
+                            modifier = Modifier
+                                .size(40.dp)
+                                .clip(CircleShape),
+                            color = PrimaryColor.copy(alpha = 0.2f)
+                        ) {
+                            Icon(
+                                Icons.Filled.Person,
+                                contentDescription = null,
+                                tint = FontIconColor,
+                                modifier = Modifier.padding(8.dp)
+                            )
+                        }
+
+                        Spacer(Modifier.width(12.dp))
+
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                text = displayName,
+                                style = AppTypography.bodyLarge.copy(
+                                    fontFamily = Poppins,
+                                    fontWeight = FontWeight.Bold
+                                ),
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis
+                            )
+                            if (chat.lastMessage.isNotBlank()) {
+                                Spacer(Modifier.height(4.dp))
+                                Text(
+                                    text = chat.lastMessage,
+                                    style = AppTypography.bodyMedium.copy(
+                                        fontFamily = Cabin,
+                                        color = FontIconColor.copy(alpha = 0.7f)
+                                    ),
+                                    maxLines = 2,
+                                    overflow = TextOverflow.Ellipsis
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/wheeldeal/ui/screens/ChatScreen.kt
+++ b/app/src/main/java/com/example/wheeldeal/ui/screens/ChatScreen.kt
@@ -5,7 +5,12 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.Send
+import androidx.compose.material.icons.filled.Call
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -13,106 +18,205 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.compose.ui.unit.sp
+import androidx.navigation.NavHostController
+import com.example.wheeldeal.ui.theme.AppTypography
+import com.example.wheeldeal.ui.theme.Cabin
+import com.example.wheeldeal.ui.theme.FontIconColor
+import com.example.wheeldeal.ui.theme.Poppins
+import com.example.wheeldeal.ui.theme.PrimaryColor
+import com.example.wheeldeal.ui.theme.WhiteColor
 import com.example.wheeldeal.viewmodel.ChatViewModel
 import com.google.firebase.auth.FirebaseAuth
-import androidx.compose.material3.HorizontalDivider
+import com.google.firebase.firestore.FirebaseFirestore
+import kotlinx.coroutines.tasks.await
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ChatScreen(
     chatId: String,
     receiverId: String,
-    chatViewModel: ChatViewModel = viewModel()
+    navController: NavHostController,
+    chatViewModel: ChatViewModel = androidx.lifecycle.viewmodel.compose.viewModel()
 ) {
-    val context = LocalContext.current
-    val currentUserId = FirebaseAuth.getInstance().currentUser?.uid ?: ""
-    var messageText by remember { mutableStateOf(TextFieldValue("")) }
+    val context    = LocalContext.current
+    val currentUser = FirebaseAuth.getInstance().currentUser?.uid.orEmpty()
+    var draft      by remember { mutableStateOf(TextFieldValue()) }
+    val messages   by chatViewModel.messages.collectAsState()
 
-    val messages by chatViewModel.messages.collectAsState()
-
-    // Listen to messages in real-time
     LaunchedEffect(chatId) {
-        chatViewModel.loadChat(receiverId)
+        if (chatId.isNotBlank()) chatViewModel.listenToMessages(chatId)
     }
 
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(Color(0xFFF8F8F8))
-            .padding(12.dp)
+    val displayName by produceState(initialValue = "", key1 = receiverId) {
+        val doc = FirebaseFirestore.getInstance()
+            .collection("users")
+            .document(receiverId)
+            .get()
+            .await()
+        val f = doc.getString("firstName").orEmpty()
+        val l = doc.getString("lastName").orEmpty()
+        value = listOf(f, l).filter(String::isNotBlank).joinToString(" ")
+    }
+
+    Column(modifier = Modifier
+        .fillMaxSize()
+        .background(WhiteColor)
     ) {
-        Text(
-            text = "Chat",
-            style = MaterialTheme.typography.titleLarge,
-            modifier = Modifier.align(Alignment.CenterHorizontally)
-        )
-
-        Spacer(modifier = Modifier.height(8.dp))
-
-        HorizontalDivider(thickness = 1.dp, color = Color.Gray.copy(alpha = 0.3f))
-
-        LazyColumn(
-            modifier = Modifier
-                .weight(1f)
-                .fillMaxWidth(),
-            reverseLayout = true
+        // Header
+        Row(
+            Modifier
+                .fillMaxWidth()
+                .background(FontIconColor)
+                .padding(horizontal = 16.dp, vertical = 14.dp),
+            verticalAlignment = Alignment.CenterVertically
         ) {
-            items(messages.reversed()) { message ->
-                val isSentByMe = message.senderId == currentUserId
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(vertical = 4.dp),
-                    contentAlignment = if (isSentByMe) Alignment.CenterEnd else Alignment.CenterStart
+            IconButton(
+                onClick = { navController.popBackStack() },
+                modifier = Modifier.size(36.dp)
+            ) {
+                Icon(
+                    Icons.AutoMirrored.Filled.ArrowBack,
+                    contentDescription = "Back",
+                    tint = WhiteColor
+                )
+            }
+
+            Text(
+                displayName.ifBlank { "Chat" },
+                style = AppTypography.headlineLarge.copy(
+                    fontSize = 20.sp,
+                    color = WhiteColor,
+                    fontFamily = Poppins
+                ),
+                textAlign = TextAlign.Center,
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(start = 8.dp)
+            )
+
+            IconButton(
+                onClick = { /* TODO: call */ },
+                modifier = Modifier.size(36.dp)
+            ) {
+                Icon(
+                    Icons.Filled.Call,
+                    contentDescription = "Call",
+                    tint = WhiteColor
+                )
+            }
+        }
+
+        Divider(color = Color.LightGray, thickness = 1.dp)
+
+        // Message list
+        LazyColumn(
+            Modifier
+                .weight(1f)
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+            reverseLayout = true,
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            items(messages.reversed()) { msg ->
+                val mine = msg.senderId == currentUser
+                Row(
+                    Modifier.fillMaxWidth(),
+                    horizontalArrangement =
+                        if (mine) Arrangement.End else Arrangement.Start
                 ) {
+                    // both sides use the same fully‑rounded shape
+                    val bubbleShape = RoundedCornerShape(20.dp)
+                    // mine = yellow, other = light surfaceVariant
+                    val bubbleColor = if (mine)
+                        PrimaryColor
+                    else
+                        MaterialTheme.colorScheme.surfaceVariant
+                    // ensure the text contrasts properly
+                    val textColor = if (mine)
+                        MaterialTheme.colorScheme.onPrimary
+                    else
+                        MaterialTheme.colorScheme.onSurfaceVariant
+
                     Surface(
-                        color = if (isSentByMe) Color(0xFFDCF8C6) else Color.White,
-                        shape = RoundedCornerShape(16.dp),
-                        shadowElevation = 2.dp
+                        shape          = bubbleShape,
+                        color          = bubbleColor,
+                        shadowElevation = 2.dp,
+                        modifier       = Modifier
+                            .widthIn(max = 280.dp)     // constrain width
+                            .padding(vertical = 4.dp)  // spacing between rows
                     ) {
                         Text(
-                            text = message.message,
-                            modifier = Modifier.padding(10.dp),
-                            color = Color.Black
+                            text = msg.message,
+                            style = AppTypography.bodyMedium.copy(
+                                fontFamily = if (mine) Poppins else Cabin
+                            ),
+                            color = textColor,
+                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 10.dp)
                         )
                     }
                 }
             }
         }
 
-        Spacer(modifier = Modifier.height(12.dp))
+        Divider(color = Color.LightGray, thickness = 1.dp)
 
+        // Input row
         Row(
-            verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier.fillMaxWidth()
+            Modifier
+                .fillMaxWidth()
+                .background(WhiteColor)
+                .padding(12.dp),
+            verticalAlignment = Alignment.CenterVertically
         ) {
-            OutlinedTextField(
-                value = messageText,
-                onValueChange = { messageText = it },
+            TextField(
+                value = draft,
+                onValueChange = { draft = it },
+                placeholder = {
+                    Text("Type a message...", style = AppTypography.bodyMedium.copy(
+                        fontFamily = Cabin
+                    ))
+                },
                 modifier = Modifier
                     .weight(1f)
-                    .padding(end = 8.dp),
-                placeholder = { Text("Type a message...") },
-                shape = RoundedCornerShape(24.dp)
-            )
-            Button(
-                onClick = {
-                    if (messageText.text.isNotBlank()) {
-                        chatViewModel.sendMessage(
-                            chatId = chatId,
-                            senderId = currentUserId,
-                            receiverId = receiverId,
-                            message = messageText.text
+                    .heightIn(min = 56.dp),
+                shape = RoundedCornerShape(28.dp),
+                colors = TextFieldDefaults.colors(
+                    focusedContainerColor = WhiteColor,
+                    unfocusedContainerColor = WhiteColor,
+                    focusedIndicatorColor = Color.Transparent,
+                    unfocusedIndicatorColor = Color.Transparent
+                ),
+                textStyle = AppTypography.bodyMedium.copy(fontFamily = Cabin),
+                trailingIcon = {
+                    IconButton(
+                        onClick = {
+                            if (draft.text.isNotBlank()) {
+                                chatViewModel.sendMessage(
+                                    chatId = chatId,
+                                    senderId = currentUser,
+                                    receiverId = receiverId,
+                                    message = draft.text
+                                )
+                                draft = TextFieldValue()
+                            } else {
+                                Toast.makeText(context, "Enter a message", Toast.LENGTH_SHORT).show()
+                            }
+                        },
+                        modifier = Modifier
+                            .size(44.dp)
+                            .background(PrimaryColor, shape = CircleShape)
+                    ) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.Send,
+                            contentDescription = "Send",
+                            tint = FontIconColor
                         )
-                        messageText = TextFieldValue("")
-                    } else {
-                        Toast.makeText(context, "Enter a message", Toast.LENGTH_SHORT).show()
                     }
                 }
-            ) {
-                Text("Send")
-            }
+            )
         }
     }
 }

--- a/app/src/main/java/com/example/wheeldeal/ui/screens/ChatScreen.kt
+++ b/app/src/main/java/com/example/wheeldeal/ui/screens/ChatScreen.kt
@@ -33,7 +33,7 @@ fun ChatScreen(
 
     // Listen to messages in real-time
     LaunchedEffect(chatId) {
-        chatViewModel.listenToMessages(chatId)
+        chatViewModel.loadChat(receiverId)
     }
 
     Column(

--- a/app/src/main/java/com/example/wheeldeal/ui/screens/MainScreen.kt
+++ b/app/src/main/java/com/example/wheeldeal/ui/screens/MainScreen.kt
@@ -45,7 +45,7 @@ fun MainScreen(
     Scaffold(
         topBar = {
             TopNavigationBar(
-                onMessageClick = { /* handle messages */ },
+                onMessageClick = { innerNav.navigate(Screen.ChatList.route) },
                 onNotificationClick = { innerNav.navigate("notifications") }
             )
         },
@@ -122,10 +122,15 @@ fun MainScreen(
                          listing       = listing,
                           navController = innerNav)
                 }
+
+                composable(Screen.ChatList.route) {
+                    ChatListScreen(navController = innerNav)
+                }
+
                 composable(Screen.Chat.route) { backStackEntry ->
                     val chatId     = backStackEntry.arguments?.getString("chatId")     ?: ""
                     val receiverId = backStackEntry.arguments?.getString("receiverId") ?: ""
-                    ChatScreen(chatId = chatId, receiverId = receiverId)
+                    ChatScreen(chatId = chatId, receiverId = receiverId,navController = innerNav )
                 }
             }
     }


### PR DESCRIPTION
- Fixed Firestore path handling in ChatRepository to reliably create & fetch chats
- Extended Screen routes with ChatList and Chat destinations
- Built ChatListScreen: lists all user conversations with avatars, names, and last messages
- Crafted ChatScreen: custom colored header, nicely styled sent & received bubbles, and input bar
- Hooked up MainScreen’s message icon to navigate into ChatList

This brings full messaging support—data, navigation, and polished interfaces—into the app.
